### PR TITLE
fix watch issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,3 +6,5 @@ Elixir.config.js.browserify.transformers.push({
     // https://github.com/vuejs/vueify#usage
     options: {}
 });
+
+Elixir.config.js.browserify.watchify.options.poll = true;


### PR DESCRIPTION
This way `watch` works for *.js and *.vue files on all OSes.

Issue solving: https://github.com/JeffreyWay/laravel-elixir-vueify/issues/11
