### PR TITLE
Fix problem with laravel-elixir 6.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 var Elixir = require('laravel-elixir');
 
+require('laravel-elixir-browserify-official');
+
 Elixir.config.js.browserify.transformers.push({
     name: 'vueify',
 


### PR DESCRIPTION
After laravel-elixir requires [another package](https://github.com/JeffreyWay/laravel-elixir-browserify) for browserify, the laravel-elixir-vueify stoped working (at least for me and some others). This fix it.
Also run: `npm install laravel-elixir-browserify-official --save-dev`
